### PR TITLE
Miscellaneous polish

### DIFF
--- a/src/helpers/countUnreadMessages.test.ts
+++ b/src/helpers/countUnreadMessages.test.ts
@@ -1,7 +1,7 @@
 import { bethZell, calvinHobbes, isaiahWilliams } from "mocks/members";
 import { countUnreadMessages } from "./countUnreadMessages";
 
-describe.skip("countUnreadMessages", () => {
+describe("countUnreadMessages", () => {
   it("counts read: false", () => {
     expect(countUnreadMessages(isaiahWilliams.messages)).toEqual(1);
   });

--- a/stories/2-unread-messages-tag.md
+++ b/stories/2-unread-messages-tag.md
@@ -18,7 +18,8 @@ Story #1 implemented a `countUnreadMessages` function.
 
 ## Feature Requirements
 
-1. An `<UnreadMessageTag />` should display to the right of each member name. This component is already written, but is not yet rendered anywhere.
-2. The tag should indicate the number of unread messages.
-3. Users with zero unread messages should not have a tag.
-4. Users with one unread message should have the word "Message" instead of "Messages."
+1. An `<UnreadMessageTag />` should display near each member name. This component is already written, but is not yet rendered anywhere.
+2. The tag should indicate the number of unread messages, example: "2 Unread Messages"
+3. Don't worry about styling for this story.
+4. Users with zero unread messages should not have a tag.
+5. Users with one unread message should have the word "Message" instead of "Messages."

--- a/stories/3-avatar-images.md
+++ b/stories/3-avatar-images.md
@@ -14,7 +14,7 @@
 
 Member records are pulled from an API (https://randomuser.me).
 
-Story #2 rendered the sorted member names and UnreadMessageTag elements in `MemberDataContainer`.
+Story #2 rendered the member names and UnreadMessageTag elements in `MemberDataContainer`.
 
 ## Feature Requirements
 

--- a/stories/4-countries.md
+++ b/stories/4-countries.md
@@ -12,7 +12,7 @@
 
 ## Existing Behavior
 
-Each member from the API has an associated country.
+Each member from the API has an associated country (use location: country rather than nat).
 
 ## Feature Requirements
 


### PR DESCRIPTION
- Remove describe.skip from Q1 tests, they're useful
- Remove styling elements from Q2, let that come into play in Q3 with the image
- More specific instructions for unread message text
- Remove confusing reference to s orting in Q3
- Specify what key to use for country in Q4